### PR TITLE
Fix typo in methods list, added 3 missing methods

### DIFF
--- a/src/auto-thread.ts
+++ b/src/auto-thread.ts
@@ -19,7 +19,10 @@ const METHODS = new Set([
     "sendGame",
     "sendMediaGroup",
     "copyMessage",
-    "forwardMessage ",
+    "copyMessages",
+    "forwardMessage",
+    "forwardMessages",
+    "sendChatAction",
 ]);
 
 export function autoThread<C extends Context>(): MiddlewareFn<C> {


### PR DESCRIPTION
I noticed that one of the methods didn't work since it contained a typo. I also added
```typescript
[
  'forwardMessages',
  'sendChatAction',
  'copyMessages',
]
```
as they were missing.
